### PR TITLE
Bundle return

### DIFF
--- a/src/main/java/io/github/linuxforhealth/api/MessageTemplate.java
+++ b/src/main/java/io/github/linuxforhealth/api/MessageTemplate.java
@@ -5,6 +5,8 @@
  */
 package io.github.linuxforhealth.api;
 
+import org.hl7.fhir.r4.model.Bundle;
+
 import java.util.List;
 
 /**
@@ -43,6 +45,16 @@ public interface  MessageTemplate<T> {
    * @return {@link List} of {@link FHIRResourceTemplate}
    */
   List<FHIRResourceTemplate> getResources();
+
+  /**
+   * Takes input and converts it to FHIR bundle resource
+   *
+   * @param data - Input
+   * @param engine - {@link MessageEngine}
+   * @return Bundle - {@link Bundle} FHIR bundle
+   *
+   */
+  Bundle convertToBundle(T data, MessageEngine engine);
 
 
 }

--- a/src/main/java/io/github/linuxforhealth/fhir/FHIRContext.java
+++ b/src/main/java/io/github/linuxforhealth/fhir/FHIRContext.java
@@ -61,7 +61,14 @@ public class FHIRContext {
         return validator;
     }
 
-    public String encodeResourceToString(Bundle bundle) {
+    public String encodeResourceToString(Bundle bundle){
+        if (validateResource){
+            validate(bundle);
+        }
+        return this.parser.encodeResourceToString(bundle);
+    }
+
+    public void validate(Bundle bundle) {
         if (validateResource) {
             ValidationResult result = getValidator().validateWithResult(bundle);
             // The result object now contains the validation results
@@ -83,8 +90,9 @@ public class FHIRContext {
                 }
 
             }
+
         }
-        return this.parser.encodeResourceToString(bundle);
+
     }
 
     private static void initValidator() {

--- a/src/main/java/io/github/linuxforhealth/hl7/message/HL7MessageModel.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/message/HL7MessageModel.java
@@ -42,6 +42,16 @@ public class HL7MessageModel implements MessageTemplate<Message> {
 
   }
 
+  private void handleException(Exception e){
+    StackTraceElement[] stackTrace = e.getStackTrace();
+    StringBuilder classAndStack = new StringBuilder();
+    classAndStack.append(e.getClass()+"\n");
+    for(int i=0; i < stackTrace.length; i++) {
+      classAndStack.append(stackTrace[i] +"\n");
+    }
+    LOGGER.error("Error transforming HL7 message. {}",classAndStack);
+  }
+
 
 
   public String convert(String message, MessageEngine engine) throws IOException {
@@ -65,6 +75,48 @@ public class HL7MessageModel implements MessageTemplate<Message> {
 
   }
 
+  public Bundle convertToBundle(String message, MessageEngine engine) throws IOException{
+    Preconditions.checkArgument(StringUtils.isNotBlank(message),
+            "Input Hl7 message cannot be blank");
+    HL7HapiParser hparser = null;
+    try {
+      hparser = new HL7HapiParser();
+
+      Message hl7message = hparser.getParser().parse(message);
+      return convertToBundle(hl7message, engine);
+
+
+    } catch (HL7Exception e) {
+      throw new IllegalArgumentException("Cannot parse the message.", e);
+    } finally {
+      if (hparser != null) {
+        hparser.getContext().close();
+      }
+    }
+  }
+
+  public Bundle convertToBundle(Message message, MessageEngine engine){
+    Preconditions.checkArgument(message != null, "Input Hl7 message cannot be null");
+    Preconditions.checkArgument(engine != null, "MessageEngine cannot be null");
+
+    HL7DataExtractor hl7DTE = new HL7DataExtractor(message);
+    HL7MessageData dataSource = new HL7MessageData(hl7DTE);
+
+    Bundle bundle = null;
+
+    // Catch any exceptions and log them without the message.
+    // NOTE: We have seen PHI in these exception messages.
+    try {
+      bundle = engine.transform(dataSource, this.getResources(), new HashMap<>());
+      engine.getFHIRContext().validate(bundle);
+    }
+    catch(Exception e) {
+      // Print stack class and trace without the error message.
+      handleException(e);
+    }
+
+    return bundle;
+  }
 
   @Override
   public String convert(Message message, MessageEngine engine) {
@@ -84,13 +136,7 @@ public class HL7MessageModel implements MessageTemplate<Message> {
     }
     catch(Exception e) {
         // Print stack class and trace without the error message.
-        StackTraceElement[] stackTrace = e.getStackTrace();
-        StringBuilder classAndStack = new StringBuilder();
-        classAndStack.append(e.getClass()+"\n");
-        for(int i=0; i < stackTrace.length; i++) {
-        	classAndStack.append(stackTrace[i] +"\n");
-        }
-        LOGGER.error("Error transforming HL7 message. {}",classAndStack);
+       handleException(e);
     }
 
     return result;

--- a/src/main/resources/hl7/datatype/CodeableConcept_var.yml
+++ b/src/main/resources/hl7/datatype/CodeableConcept_var.yml
@@ -12,6 +12,11 @@ coding:
     valueOf: datatype/Coding
     expressionType: resource
     condition: $code NOT_NULL
+    # Coding uses these scope vars: 
+    # $code
+    # $system
+    # $display
+    # $version
 
 text:  
      valueOf: $text

--- a/src/main/resources/hl7/datatype/Identifier_var.yml
+++ b/src/main/resources/hl7/datatype/Identifier_var.yml
@@ -1,12 +1,12 @@
 #
-# (C) Copyright IBM Corp. 2020
+# (C) Copyright IBM Corp. 2020, 2022
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 # Creates an identifier, you must provide all the values and variables, including those for CodeableConcept_var
 ---
 
-# Used when a coding is not availble but separate values are
+# Used when a coding is not available but separate values are
 type_1: 
    condition: $code NOT_NULL && $coding NULL
    valueOf: datatype/CodeableConcept_var

--- a/src/main/resources/hl7/datatype/Identifier_var.yml
+++ b/src/main/resources/hl7/datatype/Identifier_var.yml
@@ -5,10 +5,26 @@
 #
 # Creates an identifier, you must provide all the values and variables, including those for CodeableConcept_var
 ---
-type: 
+
+# Used when a coding is not availble but separate values are
+type_1: 
+   condition: $code NOT_NULL && $coding NULL
    valueOf: datatype/CodeableConcept_var
    generateList: true
    expressionType: resource
+    # CodeableConcept_var uses these scope vars: 
+    # $code (for CodeableConcept.Coding.code)
+    # $system (for CodeableConcept.Coding.system)
+    # $display (for CodeableConcept.Coding.display)
+    # $version (for CodeableConcept.Coding.version)
+    # $text (for CodeableConcept.text)
+
+# Used when a coding is available
+type_2:
+    condition: $coding NOT_NULL && $code NULL 
+    valueOf: datatype/CodeableConcept
+    generateList: true
+    expressionType: resource
     
 value:
    type: STRING

--- a/src/main/resources/hl7/resource/RelatedPerson.yml
+++ b/src/main/resources/hl7/resource/RelatedPerson.yml
@@ -23,11 +23,14 @@ identifier:
    generateList: true
    expressionType: resource
    vars:
+      # For identifier.value
       valueIn: String, IN1.49.1 
-   constants:
-      system: http://terminology.hl7.org/CodeSystem/v2-0203
-      code: XV
-      display: "Health Plan Identifier"
+      # For identifier.system; systemCX will process and remove spaces
+      systemCX: IN1.49.4
+      # For identifier.type, code, system, & display.
+      # Because IN1.49.5 is an ID code, this will create a correct coding
+      # because it knows the table from position and looks up the display
+      coding: CODING_SYSTEM_V2_IDENTIFIER, IN1.49.5
 
 patient: 
    valueOf: datatype/Reference

--- a/src/main/resources/hl7/resource/RelatedPerson.yml
+++ b/src/main/resources/hl7/resource/RelatedPerson.yml
@@ -1,5 +1,5 @@
 #
-# (C) Copyright IBM Corp. 2020, 2021
+# (C) Copyright IBM Corp. 2020, 2022
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -23,7 +23,8 @@ identifier:
    generateList: true
    expressionType: resource
    vars:
-      # For identifier.value
+      # For identifier.value; required for valid identifier, 
+      # does not require and not dependent on IN1.49.4 or IN1.49.5
       valueIn: String, IN1.49.1 
       # For identifier.system; systemCX will process and remove spaces
       systemCX: IN1.49.4

--- a/src/test/java/io/github/linuxforhealth/FHIRConverterTest.java
+++ b/src/test/java/io/github/linuxforhealth/FHIRConverterTest.java
@@ -15,20 +15,13 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import ca.uhn.fhir.context.FhirContext;
 import org.apache.commons.io.IOUtils;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.*;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.Bundle.BundleType;
-import org.hl7.fhir.r4.model.CodeableConcept;
-import org.hl7.fhir.r4.model.Coding;
-import org.hl7.fhir.r4.model.Identifier;
-import org.hl7.fhir.r4.model.Immunization;
-import org.hl7.fhir.r4.model.Organization;
-import org.hl7.fhir.r4.model.Quantity;
-import org.hl7.fhir.r4.model.Resource;
-import org.hl7.fhir.r4.model.ResourceType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -49,6 +42,26 @@ class FHIRConverterTest {
     private static final String HL7_FILE_WIN_NEWLINE = "src/test/resources/sample_win.hl7";
     private static final ConverterOptions OPTIONS = new Builder().withValidateResource().withPrettyPrint().build();
     private static final Logger LOGGER = LoggerFactory.getLogger(FHIRConverterTest.class);
+
+    @Test
+    void test_patient_encounter_bundle_Return() throws IOException {
+
+        String hl7message = "MSH|^~\\&|SE050|050|PACS|050|20120912011230||ADT^A01|102|T|2.6|||AL|NE|764|ASCII||||||^4086::132:2A57:3C28^IPv6\r"
+                + "EVN||201209122222\r"
+                + "PID|0010||PID1234^5^M11^A^MR^HOSP~1234568965^^^USA^SS||DOE^JOHN^A^||19800202|F||W|111 TEST_STREET_NAME^^TEST_CITY^NY^111-1111^USA||(905)111-1111|||S|ZZ|12^^^124|34-13-312||||TEST_BIRTH_PLACE\r"
+                + "PV1|1|ff|yyy|EL|ABC||200^ATTEND_DOC_FAMILY_TEST^ATTEND_DOC_GIVEN_TEST|201^REFER_DOC_FAMILY_TEST^REFER_DOC_GIVEN_TEST|202^CONSULTING_DOC_FAMILY_TEST^CONSULTING_DOC_GIVEN_TEST|MED|||||B6|E|272^ADMITTING_DOC_FAMILY_TEST^ADMITTING_DOC_GIVEN_TEST||48390|||||||||||||||||||||||||201409122200|20150206031726\r"
+                + "OBX|1|TX|1234||ECHOCARDIOGRAPHIC REPORT||||||F|||||2740^TRDSE^Janetary~2913^MRTTE^Darren^F~3065^MGHOBT^Paul^J~4723^LOTHDEW^Robert^L|\r"
+                + "AL1|1|DRUG|00000741^OXYCODONE||HYPOTENSION\r" + "AL1|2|DRUG|00001433^TRAMADOL||SEIZURES~VOMITING\r"
+                + "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625";
+
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+        Bundle bundle = ftv.convertToBundle(hl7message, OPTIONS);
+
+        List<List<Identifier>> o = bundle.getEntry().stream().filter(entry -> ResourceType.Patient == entry.getResource().getResourceType()).map(entry -> ((Patient)entry.getResource()).getIdentifier()).collect(Collectors.toList());
+
+        verifyResult( FhirContext.forR4().newJsonParser().encodeResourceToString(bundle), Constants.DEFAULT_BUNDLE_TYPE);
+
+    }
 
     @Test
     void test_patient_encounter() throws IOException {

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7FinancialInsuranceTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7FinancialInsuranceTest.java
@@ -250,8 +250,8 @@ class Hl7FinancialInsuranceTest {
     })
     // Tests IN1.17 coverage by related person. A related person should be created and cross-referenced.
     // Also tests backup field for coverage.order
-    void testInsuranceCoverageByRelatedFields(String messageType) throws IOException {
 
+    void testInsuranceCoverageByRelatedFields(String messageType) throws IOException {
         String hl7message = "MSH|^~\\&|||||20151008111200||"+messageType+"|MSGID000001|T|2.6|||||||||\n"
                 + "EVN||20210407191342||||||\n"
                 + "PID|||MR1^^^XYZ^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
@@ -287,8 +287,12 @@ class Hl7FinancialInsuranceTest {
                 // IN1.43 to RelatedPerson.gender
                 // IN1.46 to Identifier 3
                 // IN1.49 to RelatedPerson.identifier
+                //    IN1.49.1 to RelatedPerson.identifier.value
+                //    IN1.49.4 to RelatedPerson.identifier.system
+                //    IN1.49.5 to RelatedPerson.identifier.type.code (must be from terminology.hl7.org/3.0.0/CodeSystem-v2-0203.html)
+                //      NOTE: Purposely XX to ensure we are doing a lookup, and not getting bleed from other hard-coded XV uses
                 // IN1.50 through IN1.53 NOT REFERENCED
-                + "|MEMBER36|||||||F|||Value46|||J494949||||\n";
+                + "|MEMBER36|||||||F|||Value46|||J494949^^^Large HMO^XX||||\n";
 
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
@@ -322,10 +326,10 @@ class Hl7FinancialInsuranceTest {
 
         // Check RelatedPerson identifier
         assertThat(related.getIdentifier()).hasSize(1);
-        assertThat(related.getIdentifier().get(0).getValue()).isEqualTo("J494949"); // IN1.49
-        assertThat(related.getIdentifier().get(0).getSystem()).isNull();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(related.getIdentifier().get(0).getType(), "XV",
-                "Health Plan Identifier",
+        assertThat(related.getIdentifier().get(0).getValue()).isEqualTo("J494949"); // IN1.49.1
+        assertThat(related.getIdentifier().get(0).getSystem()).isEqualTo("urn:id:Large_HMO"); // IN1.49.4
+        DatatypeUtils.checkCommonCodeableConceptAssertions(related.getIdentifier().get(0).getType(), "XX", // IN1.49.5
+                "Organization identifier",
                 "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         // Check RelatedPerson name. IN1.16 name is standard XPN, tested exhaustively in other tests.        

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7FinancialInsuranceTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7FinancialInsuranceTest.java
@@ -329,7 +329,7 @@ class Hl7FinancialInsuranceTest {
         assertThat(related.getIdentifier().get(0).getValue()).isEqualTo("J494949"); // IN1.49.1
         assertThat(related.getIdentifier().get(0).getSystem()).isEqualTo("urn:id:Large_HMO"); // IN1.49.4
         DatatypeUtils.checkCommonCodeableConceptAssertions(related.getIdentifier().get(0).getType(), "XX", // IN1.49.5
-                "Organization identifier",
+                "Organization identifier", // Display value looked up from code 'XX'
                 "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         // Check RelatedPerson name. IN1.16 name is standard XPN, tested exhaustively in other tests.        


### PR DESCRIPTION
- Added a new function to API that returns the FHIR Bundle `org.hl7.fhir.r4.model.Bundle` as is (does not encode to STring)
- Refactored validation into its own method
- other minor refactorings